### PR TITLE
Added table under charts that displays on startup

### DIFF
--- a/chart demo/index.html
+++ b/chart demo/index.html
@@ -4,6 +4,20 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Charts.js</title>
+    <!-- Table Styling -->
+    <style>
+        table {
+          border-collapse: collapse;
+          width: 100%;
+          margin-top: 20px;
+        }
+    
+        th, td {
+          border: 1px solid #dddddd;
+          text-align: left;
+          padding: 8px;
+        }
+      </style>
     <!-- 
         Bootstrap
     -->
@@ -31,11 +45,127 @@
     </div>
 
 
+    <!--
+        This div is for the filtering section and data table. It only need a singular row.
+    -->
+    <div class="container">
+        <div class="row">
+            <!-- This creates a dropdown menu for filtering options -->
+            <label for="dropdown_list">Look for:</label>
+                                                <!-- THIS is a function that is triggered upon upon changing the filter option.
+                                                     Function itself is in <script> below.
+                                                     NOTE: It is being sent EVERY TIME we change the filter
+                                                    -->
+            <select id="dropdown_list" onchange="filterData()">
+                <!-- First one left empty, cause the changes trigger upon CHANGING THE OPTION -->
+                <option value=""></option> 
+                <option value="everything">Everything</option>
+                <option value="TV">TVs</option>
+                <option value="Headphones">Headphones</option>
+                <option value="Laptop">Laptops</option>
+                <option value="Tablet">Tablets</option>
+                <option value="Smartphone">Smartphones</option>
+                <option value="Camera">Cameras</option>
+                <!-- More options can be added here -->
+                <!-- But they ain't gonna work, unless we add more categories to the API -->
+            </select>
+
+            <!-- Table to display filtered items -->
+            <table id="table">
+            <thead>
+                <tr>
+                <th>ID</th>
+                <th>Brand</th>
+                <th>Category</th>
+                <th>Product Name</th>
+                <th>Price</th>
+                <th>Quantity in Stock</th>
+                <th>Searches</th>
+                </tr>
+            </thead>
+            <tbody>
+                <!--
+                    HERE is where the filtered data shall be stored.
+                    Like, in browser's memory or something.
+                 -->
+            </tbody>
+            </table>
+        </div>
+    </div>
+    
+
     <!-- Bootstrap -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 
     <!-- Chart.js -->
     <script>
+        // Function to render the table with filtered data
+        function renderTable(filteredData) {
+            const tableBody = document.getElementById('table').getElementsByTagName('tbody')[0];
+            tableBody.innerHTML = '';
+
+            filteredData.forEach(item => {
+            const row = tableBody.insertRow();
+
+            // Populate each cell with the item's property
+            for (const key in item) {
+                const cell = row.insertCell();
+                cell.innerText = item[key];
+            }
+            });
+        }
+
+        // This function filters data based on the selected option in the dropdown menu
+        function filterData() {
+            const filterOption = document.getElementById('dropdown_list').value;
+
+            fetch(apiURL)
+            .then(response => response.json())
+            .then(data => {
+                let filteredData = [];
+
+                if (filterOption === 'everything') {
+                // This shows all data if "Everything" is selected
+                filteredData = data;
+                } else {
+                // Filter data based on the selected category
+                filteredData = data.filter(item => item.category === filterOption);
+                }
+
+                // Render the table with filtered data
+                renderTable(filteredData);
+            })
+            .catch(error => console.error('Error fetching data:', error));
+                //
+                // The section below CAN be deleted, that way, the table will show data with 1-2 sec delay
+                // Otherwise, it defaults to "some_schematic.json", and after those 1-2 seconds, overwrites it
+                // with whatever API sent.
+                // NOTE: Every time we select a filter, an API request is being sent. EVERY. TIME.
+                //       And no, as far as I know, it isn't possible to integrate the API data into the fetch code, or
+                //       overwrite the local JSON file. I tried.
+                //
+                fetch(backupJSON)
+                .then(response => response.json())
+                .then(data => {
+                    let filteredData = [];
+
+                    if (filterOption === 'everything') {
+                    // Show all data if "All" is selected
+                    filteredData = data;
+                    } else {
+                    // Filter data based on the selected category
+                    filteredData = data.filter(item => item.category === filterOption);
+                    }
+
+                    // Render the table with filtered data
+                    renderTable(filteredData);
+                })
+                //
+                //
+                //
+        }
+
+
 // ------------------------------------------ Using fetch() to get the data from the JSON file ------------------------------------------ //
         // This creates constants variables, one for actual API, and other as backup
         const apiURL = 'https://my.api.mockaroo.com/some_schematic.json?key=d7234cf0'
@@ -48,6 +178,7 @@
         fetch(apiURL)
             .then(response => response.json())
             .then(jsonData => {
+
                 // This creates all STOCK variables
                 let TV_stock = 0;
                 let headphones_stock = 0;
@@ -178,9 +309,9 @@
                 };
 
                 // Options
-                var barChartOptions = {
-                    // DON'T EVEN TOUCH THIS
-                    // pls
+                var doughnutChartOptions = {
+                    // Don't even bother with this
+                    // Abomination doesn't work for whatever reason anyway
                 };
 
                 // Create the abomination
@@ -188,7 +319,7 @@
                 var barChart = new Chart(barCtx, {
                     type: 'doughnut',
                     data: barChartData,
-                    options: barChartOptions
+                    options: doughnutChartOptions
                 });
             })
             // Here is the Backup request.

--- a/chart demo/index.html
+++ b/chart demo/index.html
@@ -334,6 +334,8 @@
                 fetch(backupJSON)
                     .then(response => response.json())
                     .then(jsonData => {
+                        // THIS renders the table with EVERYTHING
+                        renderTable(jsonData)
 
                     let TV_stock = 0;
                     let headphones_stock = 0;

--- a/chart demo/index.html
+++ b/chart demo/index.html
@@ -58,7 +58,7 @@
                                                     -->
             <select id="dropdown_list" onchange="filterData()">
                 <!-- First one left empty, cause the changes trigger upon CHANGING THE OPTION -->
-                <option value=""></option> 
+                <!-- <option value=""></option>  -->
                 <option value="everything">Everything</option>
                 <option value="TV">TVs</option>
                 <option value="Headphones">Headphones</option>
@@ -84,6 +84,7 @@
                 </tr>
             </thead>
             <tbody>
+                
                 <!--
                     HERE is where the filtered data shall be stored.
                     Like, in browser's memory or something.
@@ -143,7 +144,7 @@
                 // NOTE: Every time we select a filter, an API request is being sent. EVERY. TIME.
                 //       And no, as far as I know, it isn't possible to integrate the API data into the fetch code, or
                 //       overwrite the local JSON file. I tried.
-                //
+                //divs
                 fetch(backupJSON)
                 .then(response => response.json())
                 .then(data => {
@@ -167,6 +168,7 @@
 
 
 // ------------------------------------------ Using fetch() to get the data from the JSON file ------------------------------------------ //
+        
         // This creates constants variables, one for actual API, and other as backup
         const apiURL = 'https://my.api.mockaroo.com/some_schematic.json?key=d7234cf0'
         const backupJSON = 'some_schematic.json'
@@ -178,6 +180,9 @@
         fetch(apiURL)
             .then(response => response.json())
             .then(jsonData => {
+                // THIS renders the table with EVERYTHING
+                renderTable(jsonData)
+                
 
                 // This creates all STOCK variables
                 let TV_stock = 0;

--- a/chart demo/tl;dr.txt
+++ b/chart demo/tl;dr.txt
@@ -3,3 +3,16 @@ Fetches data from our API, and passes them as both charts' data
   SO HAVE IT IN THE SAME FOLDER AS "index.html" ITSELF
 
 You can also see it in here: https://kamilkadluczka.github.io/
+
+Note about the table:
+  - An API request is being sent EVERY TIME we change filter option.
+  - There is a backup table, that reads data off the JSON file.
+  - Problem: It loads first, and after 1-2 sec delay it is overwritten
+  with whatever data the API sent.
+  - I added markers around the section that has the backup. We CAN remove it, but
+  at a risk of running out of requests for our API. The table would show nothing, it that were so.
+
+  - I tried to integrate it into the fetch() thing, but it refuses to work
+  no matter what I do.
+  - I also tried to download the data from the API and overwrite the "some_schematic.json" file
+  but it also didn't work.


### PR DESCRIPTION
Added a table under the charts. NOW it should display the table on startup.

Same issues as before:
- Every filter change is another API request
- 1-2 sec delay on charts and table, if API works
- Backup table shows first, then is overwritten by the results from the API
      - The backup can be deleted, just look for "const apiURL" (without the ""), the backup section is directly above

![Zrzut ekranu (835)](https://github.com/Kacper-Mila/EDI/assets/149239317/dde2aae7-08de-438a-91b4-f62421a38497)
